### PR TITLE
feat: migrate to Istio HTTPRoute and fix release-please workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,4 +10,4 @@ jobs:
   release:
     uses: GersonRS/modern-gitops-stack/.github/workflows/modules-release-please.yaml@main
     secrets:
-      PAT: ${{ secrets.PAT }}
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/charts/kafka-ui/templates/httproute.yaml
+++ b/charts/kafka-ui/templates/httproute.yaml
@@ -1,0 +1,20 @@
+{{- $kafkaUi := index .Values "kafka-ui" | default dict }}
+{{- $httproute := $kafkaUi.httproute | default dict }}
+{{- if $httproute.enabled | default false }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kafka-ui
+spec:
+  parentRefs:
+    - name: {{ $httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ $httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ $httproute.host | quote }}
+  rules:
+    - backendRefs:
+        - name: kafka-ui
+          port: 80
+{{- end }}

--- a/locals.tf
+++ b/locals.tf
@@ -39,22 +39,18 @@ locals {
       }
 
       ingress = {
-        # -- Specifies if you want to create an ingress access
-        enabled : true
-        # -- New style ingress class name. Only possible if you use K8s 1.18.0 or later version
-        ingressClassName : "traefik"
-        # -- Additional ingress annotations
-        annotations = {
-          "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-          "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-          "traefik.ingress.kubernetes.io/router.tls"         = "true"
-        }
-        host = local.domain_full
-        # -- Ingress tls configuration for https access
-        tls = {
-          enabled    = true
-          secretName = "kafka-ui-ingres-tls"
-        }
+        enabled = false
+      }
+    }
+  }]
+
+  helm_values_httproute = [{
+    kafka-ui = {
+      httproute = {
+        enabled           = true
+        host              = local.domain
+        gateway_name      = var.gateway_name
+        gateway_namespace = var.gateway_namespace
       }
     }
   }]

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "argocd_project" "this" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
+  input = [for i in concat(local.helm_values, local.helm_values_httproute, var.helm_values) : yamlencode(i)]
 }
 
 resource "argocd_application" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,15 @@ variable "kafka_broker_name" {
   description = "kafka_broker_name"
   type        = string
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach the HTTPRoute to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace of the Istio Gateway resource."
+  type        = string
+  default     = "istio-ingress"
+}


### PR DESCRIPTION
## Changes

- Migrate from Traefik Ingress to Istio Gateway API HTTPRoute
- Add `httproute.yaml` template to wrapper chart
- Add `gateway_name` and `gateway_namespace` variables
- Add `helm_values_httproute` local and include in deep merge
- Disable kafka-ui ingress (`enabled = false`)
- Fix release-please workflow to use `PROJECT_APP_PRIVATE_KEY` secret